### PR TITLE
Fix bug with single digit longitude filenames

### DIFF
--- a/src/main/java/hu/awm/srtm/data/hgt/TileReader.java
+++ b/src/main/java/hu/awm/srtm/data/hgt/TileReader.java
@@ -50,7 +50,7 @@ public class TileReader {
 	}
 
 	private String hgtFilePath(int lat, int lon) {
-		return baseDir + "N" + lat + "E0" + lon + FILE_EXT;
+		return String.format("%sN%02dE%03d%s", baseDir, lat, lon, FILE_EXT);
 	}
 
 }


### PR DESCRIPTION
Fixes bug where longitudes with single digits won't get resolved to NASA standard (3 digits with zero-padding on the left)